### PR TITLE
Stub any_instance of Interceptor

### DIFF
--- a/test/mail_interceptor_test.rb
+++ b/test/mail_interceptor_test.rb
@@ -10,6 +10,7 @@ class MailInterceptorTest < Minitest::Test
 
   def setup
     @message = OpenStruct.new
+    stub_env_methods('test')
   end
 
   def test_normalized_deliver_emails_to
@@ -37,7 +38,6 @@ class MailInterceptorTest < Minitest::Test
     interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
                                                        subject_prefix: nil
     @message.subject = 'Forgot password'
-    stub_env_methods(interceptor, 'test')
 
     interceptor.delivering_email @message
     assert_equal "Forgot password", @message.subject
@@ -47,17 +47,16 @@ class MailInterceptorTest < Minitest::Test
     interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
                                                        subject_prefix: 'wheel'
     @message.subject = 'Forgot password'
-    stub_env_methods(interceptor, 'test')
 
     interceptor.delivering_email @message
     assert_equal "[wheel TEST] Forgot password", @message.subject
   end
 
   def test_subject_prefix_in_production
+    stub_env_methods('production')
     interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
                                                        subject_prefix: 'wheel'
     @message.subject = 'Forgot password'
-    stub_env_methods(interceptor, 'production')
 
     interceptor.delivering_email @message
     assert_equal "[wheel] Forgot password", @message.subject
@@ -90,8 +89,8 @@ class MailInterceptorTest < Minitest::Test
 
   private
 
-  def stub_env_methods(interceptor, env)
-    interceptor.stubs(:env).returns(env)
-    interceptor.stubs(:production?).returns(env == 'production')
+  def stub_env_methods(env)
+    ::MailInterceptor::Interceptor.any_instance.stubs(:env).returns(env)
+    ::MailInterceptor::Interceptor.any_instance.stubs(:production?).returns(env == 'production')
   end
 end


### PR DESCRIPTION
Add default stub to set env to ‘test’ so that you only have to override
that if you want it to be something different.

This fixes a failure in the tests I was experiencing because
test_subject_prefix_in_production couldn’t stub env until the
interceptor was instantiated, but the initializer tests for production?
in the sanitize_forward_emails_to method called in the initializer.