### PR TITLE
The activesupport gem is a runtime dependency

### DIFF
--- a/lib/mail_interceptor.rb
+++ b/lib/mail_interceptor.rb
@@ -1,3 +1,4 @@
+require "active_support/all"
 require "mail_interceptor/version"
 
 module MailInterceptor

--- a/lib/mail_interceptor.rb
+++ b/lib/mail_interceptor.rb
@@ -1,4 +1,5 @@
-require "active_support/all"
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/array'
 require "mail_interceptor/version"
 
 module MailInterceptor

--- a/mail_interceptor.gemspec
+++ b/mail_interceptor.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest"
   spec.add_runtime_dependency "activesupport"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "rake"
 end

--- a/mail_interceptor.gemspec
+++ b/mail_interceptor.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "activesupport"
+  spec.add_runtime_dependency "activesupport"
   spec.add_development_dependency "mocha"
 end

--- a/test/mail_interceptor_test.rb
+++ b/test/mail_interceptor_test.rb
@@ -1,7 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'minitest/autorun'
-require 'active_support/all'
 require 'ostruct'
 require 'mocha/mini_test'
 require_relative './../lib/mail_interceptor'


### PR DESCRIPTION
not just a development dependency, because of the use of String#blank?
and Array.wrap in MailInterceptor::Interceptor.