### PR TITLE
subject prefix issue

### DIFF
--- a/lib/mail_interceptor.rb
+++ b/lib/mail_interceptor.rb
@@ -11,11 +11,11 @@ module MailInterceptor
       @subject_prefix    = options[:subject_prefix] || ''
       @forward_emails_to = options.fetch :forward_emails_to
 
+      add_env_info_to_subject_prefix
       sanitize_forward_emails_to
     end
 
     def delivering_email message
-      add_env_info_to_subject_prefix
       add_subject_prefix message
       message.to = normalize_recipients(message.to).flatten.uniq
     end

--- a/test/mail_interceptor_test.rb
+++ b/test/mail_interceptor_test.rb
@@ -49,6 +49,10 @@ class MailInterceptorTest < Minitest::Test
 
     interceptor.delivering_email @message
     assert_equal "[wheel TEST] Forgot password", @message.subject
+
+    @message.subject = 'Another Forgot password'
+    interceptor.delivering_email @message
+    assert_equal "[wheel TEST] Another Forgot password", @message.subject
   end
 
   def test_subject_prefix_in_production


### PR DESCRIPTION
``` ruby
  def test_subject_prefix_in_test
    interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
                                                       subject_prefix: 'wheel'
    @message.subject = 'Forgot password'

    interceptor.delivering_email @message
    assert_equal "[wheel TEST] Forgot password", @message.subject

    @message.subject = 'Forgot password'
    interceptor.delivering_email @message
    assert_equal "[wheel TEST] Forgot password", @message.subject
  end
```
this scenario fails 
```
-"[wheel TEST] Forgot password"
+"[[wheel TEST] TEST] Forgot password"
```

we need to move add_env_info_to_subject_prefix from https://github.com/bigbinary/mail_interceptor/blob/master/lib/mail_interceptor.rb#L18 
to 
https://github.com/bigbinary/mail_interceptor/blob/master/lib/mail_interceptor.rb#L13

@neerajdotname 