### PR TITLE
Make environment name and intercept mail customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ MailInterceptor::Interceptor.new({ forward_emails_to: ['intercepted_emails@bigbi
                                                        'qa@bigbinary.com' })
 ```
 
+### Custom environment name
+
+If your staging environment is using the same Rails environment as
+production, you can pass in the the name of the environment and whether
+to intercept mail as options. The default is to use `Rails.env` and
+intercept mail in all environments except production.
+
+```ruby
+MailInterceptor::Interceptor.new({ env_name: ENV["INSTANCE_NAME"],
+                                   intercept_mail?: ENV["INTERCEPT_MAIL"] == '1',
+                                   forward_emails_to: ['intercepted_emails@bigbinary.com',
+                                   'qa@bigbinary.com' })
+```
+
 #### Brought to you by
 
 [![BigBinary logo](http://bigbinary.com/assets/common/logo.png)](http://BigBinary.com)

--- a/README.md
+++ b/README.md
@@ -87,16 +87,25 @@ MailInterceptor::Interceptor.new({ forward_emails_to: ['intercepted_emails@bigbi
                                                        'qa@bigbinary.com' })
 ```
 
-### Custom environment name
+### Custom environment
 
 If your staging environment is using the same Rails environment as
-production, you can pass in the the name of the environment and whether
-to intercept mail as options. The default is to use `Rails.env` and
-intercept mail in all environments except production.
+production, you can pass in an object with the name of the environment
+and whether to intercept mail as an option. The default is to use
+`Rails.env` and intercept mail in all environments except production.
 
 ```ruby
-MailInterceptor::Interceptor.new({ env_name: ENV["INSTANCE_NAME"],
-                                   intercept_mail?: ENV["INTERCEPT_MAIL"] == '1',
+class MyEnv
+  def name
+    ENV["INSTANCE_NAME"]
+  end
+
+  def intercept?
+    ENV["INTERCEPT_MAIL"] == '1'
+  end
+end
+
+MailInterceptor::Interceptor.new({ env: MyEnv.new,
                                    forward_emails_to: ['intercepted_emails@bigbinary.com',
                                    'qa@bigbinary.com' })
 ```

--- a/test/mail_interceptor_test.rb
+++ b/test/mail_interceptor_test.rb
@@ -55,6 +55,18 @@ class MailInterceptorTest < Minitest::Test
     assert_equal "[wheel TEST] Another Forgot password", @message.subject
   end
 
+  def test_subject_prefix_in_custom_staging
+    stub_env_methods('production')
+    interceptor = ::MailInterceptor::Interceptor.new env_name: 'staging',
+                                                     intercept_mail?: true,
+                                                     forward_emails_to: 'test@example.com',
+                                                     subject_prefix: 'wheel'
+    @message.subject = 'Forgot password'
+
+    interceptor.delivering_email @message
+    assert_equal "[wheel STAGING] Forgot password", @message.subject
+  end
+
   def test_subject_prefix_in_production
     stub_env_methods('production')
     interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
@@ -93,7 +105,7 @@ class MailInterceptorTest < Minitest::Test
   private
 
   def stub_env_methods(env)
-    ::MailInterceptor::Interceptor.any_instance.stubs(:env).returns(env)
-    ::MailInterceptor::Interceptor.any_instance.stubs(:production?).returns(env == 'production')
+    ::MailInterceptor::Interceptor.any_instance.stubs(:default_env_name).returns(env)
+    ::MailInterceptor::Interceptor.any_instance.stubs(:default_intercept_mail?).returns(env != 'production')
   end
 end

--- a/test/mail_interceptor_test.rb
+++ b/test/mail_interceptor_test.rb
@@ -9,33 +9,37 @@ class MailInterceptorTest < Minitest::Test
 
   def setup
     @message = OpenStruct.new
-    stub_env_methods('test')
   end
 
   def test_normalized_deliver_emails_to
-    @interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com'
+    @interceptor = ::MailInterceptor::Interceptor.new env: env,
+                                                      forward_emails_to: 'test@example.com'
     assert_equal [], @interceptor.deliver_emails_to
 
-    @interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
-                                                       deliver_emails_to: '@wheel.com'
+    @interceptor = ::MailInterceptor::Interceptor.new env: env,
+                                                      forward_emails_to: 'test@example.com',
+                                                      deliver_emails_to: '@wheel.com'
     assert_equal ["@wheel.com"], @interceptor.deliver_emails_to
 
-    @interceptor = ::MailInterceptor::Interceptor.new  forward_emails_to: 'test@example.com',
-                                                        deliver_emails_to: ['@wheel.com', '@pump.com']
+    @interceptor = ::MailInterceptor::Interceptor.new  env: env,
+                                                       forward_emails_to: 'test@example.com',
+                                                       deliver_emails_to: ['@wheel.com', '@pump.com']
     assert_equal ["@wheel.com", "@pump.com"], @interceptor.deliver_emails_to
   end
 
   def test_invocation_of_regular_expression
-    interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
-                                                      deliver_emails_to: ['@wheel.com', '@pump.com', 'john@gmail.com']
+    interceptor = ::MailInterceptor::Interceptor.new env: env,
+                                                     forward_emails_to: 'test@example.com',
+                                                     deliver_emails_to: ['@wheel.com', '@pump.com', 'john@gmail.com']
     @message.to = [ 'a@wheel.com', 'b@wheel.com', 'c@pump.com', 'd@club.com', 'e@gmail.com', 'john@gmail.com', 'sam@gmail.com']
     interceptor.delivering_email @message
     assert_equal ["a@wheel.com", "b@wheel.com", "c@pump.com", "test@example.com", "john@gmail.com"], @message.to
   end
 
   def test_no_subject_prefix_in_test
-    interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
-                                                       subject_prefix: nil
+    interceptor = ::MailInterceptor::Interceptor.new env: env,
+                                                     forward_emails_to: 'test@example.com',
+                                                     subject_prefix: nil
     @message.subject = 'Forgot password'
 
     interceptor.delivering_email @message
@@ -43,8 +47,9 @@ class MailInterceptorTest < Minitest::Test
   end
 
   def test_subject_prefix_in_test
-    interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
-                                                       subject_prefix: 'wheel'
+    interceptor = ::MailInterceptor::Interceptor.new env: env,
+                                                     forward_emails_to: 'test@example.com',
+                                                     subject_prefix: 'wheel'
     @message.subject = 'Forgot password'
 
     interceptor.delivering_email @message
@@ -55,22 +60,10 @@ class MailInterceptorTest < Minitest::Test
     assert_equal "[wheel TEST] Another Forgot password", @message.subject
   end
 
-  def test_subject_prefix_in_custom_staging
-    stub_env_methods('production')
-    interceptor = ::MailInterceptor::Interceptor.new env_name: 'staging',
-                                                     intercept_mail?: true,
+  def test_subject_prefix_in_production
+    interceptor = ::MailInterceptor::Interceptor.new env: env('production'),
                                                      forward_emails_to: 'test@example.com',
                                                      subject_prefix: 'wheel'
-    @message.subject = 'Forgot password'
-
-    interceptor.delivering_email @message
-    assert_equal "[wheel STAGING] Forgot password", @message.subject
-  end
-
-  def test_subject_prefix_in_production
-    stub_env_methods('production')
-    interceptor = ::MailInterceptor::Interceptor.new forward_emails_to: 'test@example.com',
-                                                       subject_prefix: 'wheel'
     @message.subject = 'Forgot password'
 
     interceptor.delivering_email @message
@@ -81,22 +74,25 @@ class MailInterceptorTest < Minitest::Test
     message = "forward_emails_to should not be empty"
 
     exception = assert_raises(RuntimeError) do
-      ::MailInterceptor::Interceptor.new forward_emails_to: '',
-                                          subject_prefix: 'wheel'
+      ::MailInterceptor::Interceptor.new env: env,
+                                         forward_emails_to: '',
+                                         subject_prefix: 'wheel'
     end
 
     assert_equal message, exception.message
 
     exception =  assert_raises(RuntimeError) do
-      ::MailInterceptor::Interceptor.new forward_emails_to: [],
-                                          subject_prefix: 'wheel'
+      ::MailInterceptor::Interceptor.new env: env,
+                                         forward_emails_to: [],
+                                         subject_prefix: 'wheel'
     end
 
     assert_equal message, exception.message
 
     exception =  assert_raises(RuntimeError) do
-      ::MailInterceptor::Interceptor.new forward_emails_to: [''],
-                                          subject_prefix: 'wheel'
+      ::MailInterceptor::Interceptor.new env: env,
+                                         forward_emails_to: [''],
+                                         subject_prefix: 'wheel'
     end
 
     assert_equal message, exception.message
@@ -104,8 +100,8 @@ class MailInterceptorTest < Minitest::Test
 
   private
 
-  def stub_env_methods(env)
-    ::MailInterceptor::Interceptor.any_instance.stubs(:default_env_name).returns(env)
-    ::MailInterceptor::Interceptor.any_instance.stubs(:default_intercept_mail?).returns(env != 'production')
+  def env(environment = 'test')
+    OpenStruct.new :name => environment.upcase,
+                   :intercept? => environment != 'production'
   end
 end


### PR DESCRIPTION
I found the need to use something other than `Rails.env.production?` to decide whether to intercept mail. This is because my staging instance is very close to the production instance, down to the `RAILS_ENV` value set to production.

I'm following [the recommendations from Heroku](https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment) and using environment variables for the few things that should be different between the different instances.

This PR allows for passing the name of the environment and whether mail should be intercepted as options.

I also think it's useful to rename `production?` to `intercept_mail?` because I may want to send mail in my demo instance, even though it's not strictly a production environment.

Let me know you thoughts on these changes.