### PR TITLE
Zerobounce integrated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@
 
 source 'https://rubygems.org'
 
+gem "rails", "~> 6.1.0"
+
+gem 'zerobounce', '~> 0.2.2'
+
 # Specify your gem's dependencies in mail_interceptor.gemspec
 gemspec

--- a/lib/mail_interceptor.rb
+++ b/lib/mail_interceptor.rb
@@ -30,7 +30,7 @@ module MailInterceptor
       @recipients = message.to
       to_emails_list = normalize_recipients
 
-      to_emails_list = to_emails_list.filter { |email| zerobounce_validate_email(email) } if MailInterceptor.enable_zerobounce_validation
+      to_emails_list = to_emails_list.filter { |email| zerobounce_validate_email(email) } if zerobounce_enabled?
 
       message.perform_deliveries = to_emails_list.present?
       message.to  = to_emails_list
@@ -39,6 +39,10 @@ module MailInterceptor
     end
 
     private
+
+    def zerobounce_enabled?
+      MailInterceptor.enable_zerobounce_validation && Zerobounce.configuration.apikey.present?
+    end
 
     def normalize_recipients
       return Array.wrap(recipients) unless env.intercept?
@@ -80,7 +84,7 @@ module MailInterceptor
 
     def zerobounce_validate_email(email)
       is_email_valid = Zerobounce.validate(email: email).valid?
-      print "Zerobounce validation for #{email} is #{is_email_valid ? 'valid' : 'invalid'}"
+      print "Zerobounce validation for #{email} is #{is_email_valid ? 'valid' : 'invalid'}\n"
       is_email_valid
     end 
   end

--- a/lib/mail_interceptor/enigine.rb
+++ b/lib/mail_interceptor/enigine.rb
@@ -1,0 +1,4 @@
+module MailInterceptor
+  class Engine < Rails::Engine
+  end
+end

--- a/lib/mail_interceptor/initializers/zerobounce.rb
+++ b/lib/mail_interceptor/initializers/zerobounce.rb
@@ -1,6 +1,6 @@
 require "zerobounce"
 
 Zerobounce.configure do |config|
-  config.apikey = '3f5292782bc9484b9db3c2d78789da80'
+  config.apikey = ENV['ZEROBOUNCE_API_KEY']
   config.valid_statuses = [:valid, :catch_all, :unknown]
 end

--- a/lib/mail_interceptor/initializers/zerobounce.rb
+++ b/lib/mail_interceptor/initializers/zerobounce.rb
@@ -1,0 +1,6 @@
+require "zerobounce"
+
+Zerobounce.configure do |config|
+  config.apikey = '3f5292782bc9484b9db3c2d78789da80'
+  config.valid_statuses = [:valid, :catch_all, :unknown]
+end

--- a/lib/mail_interceptor/railtie.rb
+++ b/lib/mail_interceptor/railtie.rb
@@ -1,0 +1,9 @@
+require "rails"
+
+module MailInterceptor
+  class Railtie < Rails::Railtie
+    initializer "configure_zerobounce" do
+      require "mail_interceptor/initializers/zerobounce.rb"
+    end
+  end
+end

--- a/mail_interceptor.gemspec
+++ b/mail_interceptor.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'activesupport', '>= 6'
+  spec.add_runtime_dependency 'zerobounce', '~> 0.2.2'
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'minitest', '~> 5'
   spec.add_development_dependency 'mocha', '~> 1'


### PR DESCRIPTION
POC for [this](https://github.com/bigbinary/neeto_emails/issues/89#issuecomment-1087806373)

- Converted mail interceptor to engine due to zero bounce configuration.
- `MailInterceptor` has a `enable_zerobounce_validation` config for optional zerobounce email validation.


[Demo](https://www.loom.com/share/79d09933170d4efd8661e8299c1a4bd3)
[Demo video with neetoForm](https://www.loom.com/share/8dbac21a538f48298f004ea9b1e3c23b)