### PR TITLE
CI: add GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Ruby CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version:
+          - 3.3
+          - 3.2
+          - 3.1
+          - "3.0"
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake


### PR DESCRIPTION
This PR adds a GitHub Actions configuration file.

I picked this, since the CircleCI configuration file was not only outdated, but also disabled at the CI side.

After this,

- add a GH Actions build status badge
- drop old badge
- drop old configuration file